### PR TITLE
Don't Init Disabled Touchpad SPI / M5Stack Support

### DIFF
--- a/components/drv/ili9341.c
+++ b/components/drv/ili9341.c
@@ -105,6 +105,14 @@ void ili9341_init(void)
 	///Enable backlight
 	printf("Enable backlight.\n");
 	gpio_set_level(ILI9341_BCKL, ILI9341_BCKL_ACTIVE_LVL);
+
+#if ILI9341_INVERT_DISPLAY
+	uint8_t data[] = {0x68};
+	// this same command also sets rotation (portrait/landscape) and inverts colors.
+	// https://gist.github.com/motters/38a26a66020f674b6389063932048e4c#file-ili9844_defines-h-L24
+	ili9341_send_cmd(0x36);
+	ili9341_send_data(&data, 1);
+#endif
 }
 
 

--- a/components/drv/ili9341.h
+++ b/components/drv/ili9341.h
@@ -23,6 +23,9 @@ extern "C" {
 #define ILI9341_RST  18
 #define ILI9341_BCKL 5
 
+// if text/images are backwards, try setting this to 1
+#define ILI9341_INVERT_DISPLAY 0
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/main/main.c
+++ b/main/main.c
@@ -32,8 +32,10 @@ void app_main()
 	disp_spi_init();
 	ili9341_init();
 
+#if ENABLE_TOUCH_INPUT
 	tp_spi_init();
-    xpt2046_init();
+  xpt2046_init();
+#endif
 
     static lv_color_t buf1[DISP_BUF_SIZE];
     static lv_color_t buf2[DISP_BUF_SIZE];

--- a/main/main.c
+++ b/main/main.c
@@ -34,7 +34,7 @@ void app_main()
 
 #if ENABLE_TOUCH_INPUT
 	tp_spi_init();
-  xpt2046_init();
+	xpt2046_init();
 #endif
 
     static lv_color_t buf1[DISP_BUF_SIZE];


### PR DESCRIPTION
fixes #18

The issue with my display being blank was the Touchpad SPI was being initialized even when it was disabled. Another ifdef in main solves this.

The next problem that I had is everything was inverted, like text written on a mirror. I had seen this before using the loboris driver, and created a similar configuration define.

Actually, this matter can become very complex, it seems from the [predefines](https://github.com/loboris/ESP32_TFT_library/blob/master/components/tft/tftspi.h#L72) and [switch logic](https://github.com/loboris/ESP32_TFT_library/blob/master/components/tft/tftspi.c#L788) there that there are a variety of orientation and rotation commands to achieve the same desired results just within different ili9341 based displays. An alternative to this madness might be to just support a define for the actual hex command sent with MD_CTRL (0x36) to set orientation, inversion (and even RGB, though I don't know if that diverges amongst ILI9341s.)